### PR TITLE
Major: makes select elements way easier to work with - Minor: tweak linting and form widths

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -8,6 +8,9 @@ linters:
   ColorKeyword:
     enabled: false
 
+  ColorVariable:
+    enabled: false
+
   Comment:
     enabled: false
 

--- a/src/styles/components/_forms.scss
+++ b/src/styles/components/_forms.scss
@@ -29,7 +29,7 @@ textarea {
     padding: 0.25rem 0.5rem;
     background: $white;
     border: 1px solid $gray-light;
-    min-width: 16rem;
+    width: 100%;
     border-radius: $corner-radius;
 }
 
@@ -44,14 +44,56 @@ textarea {
     margin-top: -0.5rem;
 }
 
-select {
-    //ed. note: select boxes are weird.
-    outline: none;
-    background: $white;
-    color: $black;
-    border: 1px solid $gray-light;
-    padding: 0.25rem 0.5rem;
-    height: 2rem;
-    border-radius: $corner-radius;
-    min-width: 16rem;
+// Cross-browser custom select boxes thanks to https://github.com/filamentgroup/select-css.
+
+.form--select {
+    position: relative;
+    display: block;
+
+    select {
+        width: 100%;
+        margin: 0;
+        background: none;
+        border: 1px solid $gray-light;
+        border-radius: $corner-radius;
+        outline: none;
+        appearance: none;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        // Font size must be 16px or larger to prevent iOS page zoom on focus */
+        font-size: $scale-normal;
+        // General select styles: change as needed */
+        font-family: $sans;
+        color: $gray-darker;
+        padding: 0.35rem 2rem 0.25rem 0.5rem;
+        line-height: $base-line-height;
+
+        &:hover {
+            border: 1px solid $gray;
+        }
+
+        &:focus {
+            outline: none;
+            border-color: $aqua;
+        }
+    }
+
+    option {
+        font-weight: normal;
+    }
+
+    &::after {
+        content: "";
+        position: absolute;
+        width: 0;
+        height: 0;
+        top: 50%;
+        right: 1rem;
+        margin-top: -0.25rem;
+        border-width: 0.5rem 0.325rem 0;
+        border-color: $gray-dark transparent transparent;
+        border-style: solid;
+        z-index: 2;
+        pointer-events: none;
+    }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -14,6 +14,7 @@ Bootstrap kit v0.2 - January 26 2015
 // import any vendor files
 @import "vendor/normalize";
 @import "vendor/includemedia";
+@import "vendor/selectcss";
 
 // project-wide styles - styles single elements
 @import "global/color";

--- a/src/styles/vendor/_selectcss.scss
+++ b/src/styles/vendor/_selectcss.scss
@@ -1,0 +1,30 @@
+/* ------------------------------------  */
+/* START OF UGLY BROWSER-SPECIFIC HACKS */
+/* ----------------------------------  */
+
+/* OPERA - Pre-Blink nix the custom arrow, go with a native select button to keep it simple. Targeted via this hack http://browserhacks.com/#hack-a3f166304aafed524566bc6814e1d5c7 */
+x:-o-prefocus, .form--select::after {
+  display:none;
+}
+
+ /* IE 10/11+ - This hides native dropdown button arrow so it will have the custom appearance, IE 9 and earlier get a native select - targeting media query hack via http://browserhacks.com/#hack-28f493d247a12ab654f6c3637f6978d5 - looking for better ways to achieve this targeting */
+/* The second rule removes the odd blue bg color behind the text in the select button in IE 10/11 and sets the text color to match the focus style's - fix via http://stackoverflow.com/questions/17553300/change-ie-background-color-on-unopened-focused-select-box */
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  .form--select select::-ms-expand {
+    display: none;
+  }
+  .form--select select:focus::-ms-value {
+    background: transparent;
+    color: #222;
+  }
+}
+
+/* Firefox focus has odd artifacts around the text, this kills that. See https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-focusring */
+.form--select select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+/* ------------------------------------  */
+/*  END OF UGLY BROWSER-SPECIFIC HACKS  */
+/* ------------------------------------  */

--- a/src/templates/views/styles.jade
+++ b/src/templates/views/styles.jade
@@ -240,14 +240,15 @@ block content
                     textarea#text_area(readonly='') I'm readonly
                 p
                     label(for='select_element') Select Element:
-                    select#select_element
-                        optgroup(label='Option Group 1')
-                            option(value='1') Option 1
-                            option(value='2') Option 2
-                        optgroup(label='Option Group 2')
-                            option(value='1') Option 1
-                            option(value='2') Option 2
-                            option(value='3', disabled='') Disabled Option
+                    .form--select
+                        select#select_element
+                            optgroup(label='Option Group 1')
+                                option(value='1') Option 1
+                                option(value='2') Option 2
+                            optgroup(label='Option Group 2')
+                                option(value='1') Option 1
+                                option(value='2') Option 2
+                                option(value='3', disabled='') Disabled Option
                 p
                     label(for='select_element_disabled') Disabled Select Element:
                     select#select_element_disabled(disabled='')


### PR DESCRIPTION
Add linting rule to not bug you about using 'transparent'
Style 'select' element consistently across browsers
Remove min-width for form elements in prep for upcoming form updates
