### PR TITLE
Handle BrowserSync crash from localtunnel throwing ECONNREFUSED error

### DIFF
--- a/gulp/serve.es6
+++ b/gulp/serve.es6
@@ -15,7 +15,7 @@ module.exports = function(gulp) {
         'serve:browsersync',
         'proxies the localhost server via BrowserSync to dynamically update assets',
         function(next) {
-            browserSync.init({
+            var bs = browserSync.init({
                 'port': ports.frontend,
                 'files': false,
                 'proxy': 'http://localhost:' + ports.backend,
@@ -23,6 +23,16 @@ module.exports = function(gulp) {
                 // Stop the browser from automatically opening
                 'open': false
             }, next);
+
+            // From https://github.com/BrowserSync/browser-sync/issues/823
+            // due to https://github.com/localtunnel/localtunnel/issues/81
+            bs.emitter.on('service:running', function() {
+                bs.tunnel.tunnel_cluster.on('error', function(err) {
+                    if(err.toString().indexOf('firewall') === -1)
+                        throw err;
+                    console.log('localtunnel connection lost; reconnecting...');
+                });
+            });
         }
     );
 

--- a/gulp/serve.es6
+++ b/gulp/serve.es6
@@ -1,7 +1,6 @@
 const browserSync = require('browser-sync');
 const ecstatic = require('ecstatic');
 const http = require('http');
-const path = require('path');
 
 
 module.exports = function(gulp) {
@@ -15,7 +14,7 @@ module.exports = function(gulp) {
         'serve:browsersync',
         'proxies the localhost server via BrowserSync to dynamically update assets',
         function(next) {
-            var bs = browserSync.init({
+            const bs = browserSync.init({
                 'port': ports.frontend,
                 'files': false,
                 'proxy': 'http://localhost:' + ports.backend,


### PR DESCRIPTION
This particularly annoying bug is due to the localtunnel server periodically restarting. Apparently, localtunnel will automatically reattempt to connect (good) but also throws an ECONNREFUSED error which we don't handle (bad). The latter causes BrowserSync to crash, and forces you to restart gulp in order to get everything rolling again.

As noted [here](https://github.com/BrowserSync/browser-sync/issues/823), you can catch this error and handle it while localtunnel reconnects.

@za-creature please review
