### PR TITLE
Always use double colons for pseudo-elements

### DIFF
--- a/assets/styles/components/_forms.scss
+++ b/assets/styles/components/_forms.scss
@@ -86,7 +86,7 @@ textarea {
     border-radius: 1rem;
     position: relative;
 
-    &:before {
+    &::before {
         content: '';
         display: block;
         width: 0.25rem;
@@ -110,7 +110,7 @@ textarea {
         outline: none;
         border-color: $aqua;
 
-        +span:after {
+        + span::after {
             content: '\2190';
             color: $aqua;
             display: inline-block;
@@ -121,7 +121,6 @@ textarea {
 
 .form--radio,
 .form--checkbox {
-
     label {
         font-weight: $weight-normal;
 

--- a/assets/styles/layouts/_global.scss
+++ b/assets/styles/layouts/_global.scss
@@ -4,7 +4,7 @@ html {
 }
 
 *,
-*:before,
-*:after {
+*::before,
+*::after {
     box-sizing: inherit;
 }


### PR DESCRIPTION
Fixes linting errors.

@ilikescience please review
