### PR TITLE
Incorrect key path: `bs.instance.tunnel`, not `bs.tunnel`

### DIFF
--- a/gulp/serve.es6
+++ b/gulp/serve.es6
@@ -26,7 +26,7 @@ module.exports = function(gulp) {
             // From https://github.com/BrowserSync/browser-sync/issues/823
             // due to https://github.com/localtunnel/localtunnel/issues/81
             bs.emitter.on('service:running', function() {
-                bs.tunnel.tunnel_cluster.on('error', function(err) {
+                bs.instance.tunnel.tunnel_cluster.on('error', function(err) {
                     if(err.toString().indexOf('firewall') === -1)
                         throw err;
                     console.log('localtunnel connection lost; reconnecting...');


### PR DESCRIPTION
@ilikescience please test & review
