### PR TITLE
Browserify regression

### DIFF
--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -40,8 +40,8 @@ module.exports = function(gulp, plugins, env) {
         bundler.rebuild = function(errCb) {
             return bundler.bundle()
                 .on('error', plugins.notify.onError(function(err) {
-                    if(errCb)
-                        errCb();
+                    if(errCb && typeof errCb === 'function')
+                        errCb(err.stack);
 
                     return err.message;
                 }))


### PR DESCRIPTION
At some point, watchify started sending an argument with their `update` event witch produces the following error whenever a source file contains syntax errors:

```
[01:13:57] gulp-notify: [Error running notifier] Could not send message: errCb is not a function
```

Patch converts said error into a more helpful message:

```
[01:15:46] gulp-notify: [Error running Gulp] B:/Archpaper/assets/scripts/index.js: Unterminated string constant (3:0) while parsing file: B:\Archpaper\assets\scripts\index.js
```

@endtwist Tag, you're it
