### PR TITLE
Extract styles.html to docs and remove unused css

### DIFF
--- a/docs/styles.pug
+++ b/docs/styles.pug
@@ -1,4 +1,4 @@
-extends ../layouts/default
+extends ../assets/templates/layouts/default
 
 block title
     | Airframe Style Guide

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "pug": "^2.0.0-beta4",
     "pug-loader": "^2.2.1",
     "pug-walk": "0.0.3",
+    "purifycss-webpack-plugin": "^2.0.3",
     "reload-html-webpack-plugin": "^0.1.2",
     "rimraf": "^2.5.4",
     "style-loader": "^0.13.1",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -139,11 +139,11 @@ module.exports = webpackValidator({
             template: './docs/styles.pug',
             filename: '/docs/styles.html'
         })),
-        new CopyPlugin([
+        new CopyPlugin(removeEmpty([
             // Copy fonts to build directory
             {from: 'fonts', to: 'fonts'},
             ifNotProd({from: 'images', to: 'images'})
-        ], {
+        ]), {
             ignore: [
                 '.*'
             ]


### PR DESCRIPTION
Move styles.html view to separate docs directory that is ignored
in production builds.

Add PurifyCSS to remove css that is not used in script or template
files.

@ilikescience please r/m
