### PR TITLE
Allow PUBLIC_PATH env var to modify public compiled assets path

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -41,7 +41,7 @@ module.exports = webpackValidator({
         filename: ifProd('scripts/bundle-[chunkhash:8].js', 'scripts/bundle.js'),
         path: path.resolve('build'),
         pathinfo: ifNotProd(),
-        publicPath: '/'
+        publicPath: process.env.PUBLIC_PATH || '/'
     },
     devtool: ifProd('source-map', 'eval'),
     devServer: {


### PR DESCRIPTION
I've set up the env var in CircleCI to point to `/airframe/` -- this should fix the path issue.

@andrewcoelho please r/m
