### PR TITLE
PurifyPlugin should only be passed actual paths, no undefineds

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -116,10 +116,15 @@ module.exports = webpackValidator({
         ifProd(new ExtractTextPlugin('styles/styles-[chunkhash:8].css')),
         ifProd(new PurifyPlugin({
             basePath: __dirname,
-            paths: [
-                'assets/templates/**/*.pug',
-                propIf(process.env.WITH_DOCS || false, 'docs/**/*.pug')
-            ],
+            paths: propIf(process.env.WITH_DOCS || false,
+                [
+                    'assets/templates/**/*.pug',
+                    'docs/**/*.pug'
+                ],
+                [
+                    'assets/templates/**/*.pug'
+                ]
+            ),
             purifyOptions: {
                 minify: true
             }


### PR DESCRIPTION
Encountered this bug when testing production builds of Airframe.

@andrewcoelho please r/m